### PR TITLE
tweak mu to fix #30

### DIFF
--- a/src/recurrence.jl
+++ b/src/recurrence.jl
@@ -118,7 +118,7 @@ function backwardrecurrence!(K, A, B, C, z, nN::AbstractUnitRange, j...)
             μ = min(abs(data[k,j...]/data[k-1,j...]), abs(data[k-1,j...]/data[k-2,j...]))
             # data[k] * μ^M ≤ ε
             #  M ≥ log(ε/data[k])/log(μ)
-            N = ceil(Int, max(2N, min(maxiterations, log(eps(real(T))/100)/log(μ))))
+            N = ceil(Int, max(2N, min(maxiterations, log(eps(real(T))/100)/log(μ+eps(real(T))))))
             _growdata!(K, N, j...)
             resize!(u, N)
             data = K.data

--- a/test/test_recurrence.jl
+++ b/test/test_recurrence.jl
@@ -22,6 +22,12 @@ using ClassicalOrthogonalPolynomials: recurrencecoefficients
             @test r[1:1000] ≈ ξ.^(1:1000)
             @test r[10_000] ≈ ξ.^(10_000) atol=3E-10
         end
+
+        for z in (0.2567881003580743 - 0.33437737333561895im)
+            ξ = π * (z - √(z-1) * √(z+1))
+            r = RecurrenceArray(z, recurrencecoefficients(U), [ξ,2z*ξ-π])
+            @test sizeof(r.data) < 1000_000
+        end
     end
 
     @testset "RecurrenceMatrix" begin


### PR DESCRIPTION
Sometimes μ is set to something ike 0.9999999 in Line 118, which results in `log(eps(real(T))/100)/log(μ)` being a large positive number. Adding a small constant prevents this.

It might be even safer to have `log(eps(real(T))/100)/log(μ+2*eps(real(T)))` or any other small number.